### PR TITLE
Fix 'to watch' endpoint path according to API doc

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ TVSAPI.prototype.getUser = function (callback) {
 }
 
 TVSAPI.prototype.getToWatch = function (options, callback) {
-  API.get('to-watch', options, callback)
+  API.get('to_watch', options, callback)
 }
 
 TVSAPI.prototype.getAgenda = function (options, callback) {


### PR DESCRIPTION
Hi there, I've seen the 'to watch' API endpoint path was off
Reference: https://api.tvshowtime.com/doc#to_watch
